### PR TITLE
Fix DELETE method (Stop a running program)

### DIFF
--- a/core/class/homeconnect.class.php
+++ b/core/class/homeconnect.class.php
@@ -2105,64 +2105,63 @@ class homeconnectCmd extends cmd {
 
         if ($method == 'DELETE') {
             $payload = null;
-        } else {
-            if ($this->getLogicalId() !== 'PUT::BSH.Common.Option.StartInRelative') {
-                // La commande départ différé doit être envoyée au moment du lancer de programme.
-                $parameters = array(
-                    'data' => array()
-                );
-                if ($this->getConfiguration('key') !== '') {
-                    $parameters['data']['key'] = $this->getConfiguration('key', '');
-                }
-                if ($this->getConfiguration('value') !== '') {
-                    if (is_bool($this->getConfiguration('value'))) {
-                        if ($this->getValue() != '') {
-                            $cmdValue = cmd::byId($this->getValue());
-                            if (is_object($cmdValue)) {
-                                $parameters['data']['value'] = !$cmdValue->execCmd();
-                            }
-                        } else {
-                            $parameters['data']['value'] = $this->getConfiguration('value');
+        }
+        if ($this->getLogicalId() !== 'PUT::BSH.Common.Option.StartInRelative') {
+            // La commande départ différé doit être envoyée au moment du lancer de programme.
+            $parameters = array(
+                'data' => array()
+            );
+            if ($this->getConfiguration('key') !== '') {
+                $parameters['data']['key'] = $this->getConfiguration('key', '');
+            }
+            if ($this->getConfiguration('value') !== '') {
+                if (is_bool($this->getConfiguration('value'))) {
+                    if ($this->getValue() != '') {
+                        $cmdValue = cmd::byId($this->getValue());
+                        if (is_object($cmdValue)) {
+                            $parameters['data']['value'] = !$cmdValue->execCmd();
                         }
                     } else {
-                        $parameters['data']['value'] = str_replace(array_keys($replace) , $replace, $this->getConfiguration('value', ''));
+                        $parameters['data']['value'] = $this->getConfiguration('value');
                     }
+                } else {
+                    $parameters['data']['value'] = str_replace(array_keys($replace) , $replace, $this->getConfiguration('value', ''));
                 }
-                if ($this->getConfiguration('unit', '') !== '') {
-                    $parameters['data']['unit'] = $this->getConfiguration('unit', '');
-                }
-                if ($this->getConfiguration('type', '') !== '') {
-                    $parameters['data']['type'] = $this->getConfiguration('type', '');
-                }
-                $payload = json_encode($parameters, JSON_NUMERIC_CHECK);
+            }
+            if ($this->getConfiguration('unit', '') !== '') {
+                $parameters['data']['unit'] = $this->getConfiguration('unit', '');
+            }
+            if ($this->getConfiguration('type', '') !== '') {
+                $parameters['data']['type'] = $this->getConfiguration('type', '');
+            }
+            $payload = json_encode($parameters, JSON_NUMERIC_CHECK);
 
-                $url = homeconnect::API_REQUEST_URL . '/' . $haid . '/' . $path;
-                log::add('homeconnect', 'debug', __('Paramètres de la requête pour exécuter la commande ', __FILE__));
-                log::add('homeconnect', 'debug', 'Method : ' . $method);
-                log::add('homeconnect', 'debug', 'Url : ' . $url);
-                log::add('homeconnect', 'debug', 'Payload : ' . $payload);
-                $response = homeconnect::request($url, $payload, $method, $headers);
-                log::add('homeconnect', 'debug', __('Réponse du serveur ', __FILE__) . $response);
-                // si la requête est de category program il faut mettre à jour les options
-                if ($this->getConfiguration('category') == 'Program') {
-                    $typeProgram = homeconnect::lastSegment('/', $url);
-                    $eqLogic->adjustProgramOptions($typeProgram, $this->getConfiguration('key'));
-                    // A voir dans ce cas ce qu'il faut mettre à jour.
-                }
-                $eqLogic->updateApplianceData();
-            } else {
-                $value = str_replace(array_keys($replace) , $replace, $this->getConfiguration('value', ''));
-                if ($value !== '' && $value !== 0) {
-                    $parameters = array(
-                        'key' => 'BSH.Common.Option.StartInRelative',
-                        'value' => $value,
-                        'unit' => 'seconds'
-                    );
-                    $payload = json_encode($parameters, JSON_NUMERIC_CHECK);
-                    //$payload = '{"key":"BSH.Common.Option.StartInRelative","value":' . $value. ',"unit":"seconds"}';
-                    cache::set('homeconnect::startinrelative::' . $eqLogic->getId() , $payload, '');
-                    // il faut mémoriser la valeur du départ différé.
-                }
+            $url = homeconnect::API_REQUEST_URL . '/' . $haid . '/' . $path;
+            log::add('homeconnect', 'debug', __('Paramètres de la requête pour exécuter la commande ', __FILE__));
+            log::add('homeconnect', 'debug', 'Method : ' . $method);
+            log::add('homeconnect', 'debug', 'Url : ' . $url);
+            log::add('homeconnect', 'debug', 'Payload : ' . $payload);
+            $response = homeconnect::request($url, $payload, $method, $headers);
+            log::add('homeconnect', 'debug', __('Réponse du serveur ', __FILE__) . $response);
+            // si la requête est de category program il faut mettre à jour les options
+            if ($this->getConfiguration('category') == 'Program') {
+                $typeProgram = homeconnect::lastSegment('/', $url);
+                $eqLogic->adjustProgramOptions($typeProgram, $this->getConfiguration('key'));
+                // A voir dans ce cas ce qu'il faut mettre à jour.
+            }
+            $eqLogic->updateApplianceData();
+        } else {
+            $value = str_replace(array_keys($replace) , $replace, $this->getConfiguration('value', ''));
+            if ($value !== '' && $value !== 0) {
+                $parameters = array(
+                    'key' => 'BSH.Common.Option.StartInRelative',
+                    'value' => $value,
+                    'unit' => 'seconds'
+                );
+                $payload = json_encode($parameters, JSON_NUMERIC_CHECK);
+                //$payload = '{"key":"BSH.Common.Option.StartInRelative","value":' . $value. ',"unit":"seconds"}';
+                cache::set('homeconnect::startinrelative::' . $eqLogic->getId() , $payload, '');
+                // il faut mémoriser la valeur du départ différé.
             }
         }
     }


### PR DESCRIPTION
Hi @Flobul,

I wonder for a few months how to stop a running coffee or a rise/shutdown cycle from Jeedom, as I could with HC App.

There is an issue when the method is DELETE, nothing is set to HC (see removed `else` in code).

Tested on by coffee maker, before change:
```
---> Standby via Jeedom
[2023-03-04 11:08:37][DEBUG] : Fonction execute()
[2023-03-04 11:08:37][DEBUG] : logicalId : PUT::BSH.Common.Setting.PowerState
[2023-03-04 11:08:37][DEBUG] : Options : Array ( [select] => BSH.Common.EnumType.PowerState.Standby [user_login] => bad [user_id] => 2 )
[...]
[2023-03-04 11:08:38][DEBUG] : Mise à jour setting : GET::BSH.Common.Status.OperationState - Valeur :En fonctionnement
[2023-03-04 11:08:38][DEBUG] : getCmdValueTranslation La clé BSH.Common.Root.ActiveProgram existe, mais valeur ConsumerProducts.CoffeeMaker.Program.CleaningModes.ApplianceOffRinsing est introuvable
[2023-03-04 11:08:38][DEBUG] : Mise à jour setting : GET::BSH.Common.Root.ActiveProgram - Valeur :ConsumerProducts.CoffeeMaker.Program.CleaningModes.ApplianceOffRinsing
[2023-03-04 11:08:39][DEBUG] : Mise à jour setting : GET::BSH.Common.Option.ProgramProgress - Valeur :20
[...]
[2023-03-04 11:08:41][DEBUG] : setting : Array ( [key] => BSH.Common.Setting.PowerState [value] => BSH.Common.EnumType.PowerState.On [name] => Statut [displayvalue] => Activé )
[2023-03-04 11:08:41][DEBUG] : Mise à jour setting : GET::BSH.Common.Setting.PowerState - Valeur :Activé
[2023-03-04 11:08:44][DEBUG] : Mise à jour setting : GET::BSH.Common.Option.ProgramProgress - Valeur :40

---> Abort via Jeedom
[2023-03-04 11:08:46][DEBUG] : Fonction execute()
[2023-03-04 11:08:46][DEBUG] : logicalId : DELETE::StopActiveProgram
[2023-03-04 11:08:46][DEBUG] : Options : Array ( [user_login] => bad [user_id] => 2 )
[2023-03-04 11:08:46][DEBUG] : Commande arrêter
[2023-03-04 11:08:46][DEBUG] : Nombre de requêtes envoyées aujourd'hui 337
[2023-03-04 11:08:46][DEBUG] : La requête GET	: /api/homeappliances/[REDACTED]/programs/active a réussi code = 200 résultat = { "data": { "key": "ConsumerProducts.CoffeeMaker.Program.CleaningModes.ApplianceOffRinsing", "options": [{ "key": "BSH.Common.Option.ProgramProgress", "value": 40, "unit": "%", "name": "Avancement actuel du programme" }], "name": "L'appareil est en cours de rinçage" } }
[2023-03-04 11:08:46][DEBUG] : | Commande générique

---> Abort via Jeedom (a second time to be sure)
[2023-03-04 11:08:50][DEBUG] : Fonction execute()
[2023-03-04 11:08:50][DEBUG] : logicalId : DELETE::StopActiveProgram
[2023-03-04 11:08:50][DEBUG] : Options : Array ( [user_login] => bad [user_id] => 2 )
[2023-03-04 11:08:50][DEBUG] : Commande arrêter
[2023-03-04 11:08:50][DEBUG] : Nombre de requêtes envoyées aujourd'hui 338
[2023-03-04 11:08:50][DEBUG] : La requête GET	: /api/homeappliances/[REDACTED]/programs/active a réussi code = 200 résultat = { "data": { "key": "ConsumerProducts.CoffeeMaker.Program.CleaningModes.ApplianceOffRinsing", "options": [{ "key": "BSH.Common.Option.ProgramProgress", "value": 40, "unit": "%", "name": "Avancement actuel du programme" }], "name": "L'appareil est en cours de rinçage" } }
[2023-03-04 11:08:50][DEBUG] : | Commande générique

[2023-03-04 11:08:52][DEBUG] : Mise à jour setting : GET::BSH.Common.Option.ProgramProgress - Valeur :60

---> Abort via HC App
[2023-03-04 11:08:55][DEBUG] : Mise à jour setting : GET::BSH.Common.Status.OperationState - Valeur :Abandon
[2023-03-04 11:09:10][DEBUG] : Mise à jour setting : GET::BSH.Common.Option.ProgramProgress - Valeur :100
[2023-03-04 11:09:10][DEBUG] : Mise à jour setting : GET::BSH.Common.Status.OperationState - Valeur :Prêt
[2023-03-04 11:09:10][DEBUG] : la commande info : GET::BSH.Common.Root.ActiveProgram n'a pas de valeur
[2023-03-04 11:09:10][DEBUG] : Mise à jour setting : GET::BSH.Common.Root.ActiveProgram - Valeur :
[2023-03-04 11:09:10][DEBUG] : Mise à jour setting : GET::BSH.Common.Option.ProgramProgress - Valeur :0
```

After change:
```
---> Standby via Jeedom
[2023-03-04 11:52:23][DEBUG] : Fonction execute()
[2023-03-04 11:52:23][DEBUG] : logicalId : PUT::BSH.Common.Setting.PowerState
[2023-03-04 11:52:23][DEBUG] : Options : Array ( [select] => BSH.Common.EnumType.PowerState.Standby [user_login] => bad [user_id] => 2 )
[...]
[2023-03-04 11:52:24][DEBUG] : Mise à jour setting : GET::BSH.Common.Status.OperationState - Valeur :En fonctionnement
[2023-03-04 11:52:24][DEBUG] : getCmdValueTranslation La clé BSH.Common.Root.ActiveProgram existe, mais valeur ConsumerProducts.CoffeeMaker.Program.CleaningModes.ApplianceOffRinsing est introuvable
[2023-03-04 11:52:24][DEBUG] : Mise à jour setting : GET::BSH.Common.Root.ActiveProgram - Valeur :ConsumerProducts.CoffeeMaker.Program.CleaningModes.ApplianceOffRinsing
[2023-03-04 11:52:24][DEBUG] : Mise à jour setting : GET::BSH.Common.Option.ProgramProgress - Valeur :20
[...]
[2023-03-04 11:52:27][DEBUG] : setting : Array ( [key] => BSH.Common.Setting.PowerState [value] => BSH.Common.EnumType.PowerState.On [name] => Statut [displayvalue] => Activé )
[2023-03-04 11:52:27][DEBUG] : Mise à jour setting : GET::BSH.Common.Setting.PowerState - Valeur :Activé
[2023-03-04 11:52:30][DEBUG] : Mise à jour setting : GET::BSH.Common.Option.ProgramProgress - Valeur :40

---> Abort via Jeedom
[2023-03-04 11:52:32][DEBUG] : Fonction execute()
[2023-03-04 11:52:32][DEBUG] : logicalId : DELETE::StopActiveProgram
[2023-03-04 11:52:32][DEBUG] : Options : Array ( [user_login] => bad [user_id] => 2 )
[2023-03-04 11:52:32][DEBUG] : Commande arrêter
[2023-03-04 11:52:32][DEBUG] : Nombre de requêtes envoyées aujourd'hui 375
[2023-03-04 11:52:32][DEBUG] : La requête GET	: /api/homeappliances/[REDACTED]/programs/active a réussi code = 200 résultat = { "data": { "key": "ConsumerProducts.CoffeeMaker.Program.CleaningModes.ApplianceOffRinsing", "options": [{ "key": "BSH.Common.Option.ProgramProgress", "value": 40, "unit": "%", "name": "Avancement actuel du programme" }], "name": "L'appareil est en cours de rinçage" } }
[2023-03-04 11:52:32][DEBUG] : | Commande générique
[2023-03-04 11:52:32][DEBUG] : Paramètres de la requête pour exécuter la commande :
[2023-03-04 11:52:32][DEBUG] : Method : DELETE
[2023-03-04 11:52:32][DEBUG] : Url : /api/homeappliances/[REDACTED]/programs/active
[2023-03-04 11:52:32][DEBUG] : Payload : {"data":[]}
[2023-03-04 11:52:33][DEBUG] : Nombre de requêtes envoyées aujourd'hui 376
[2023-03-04 11:52:33][DEBUG] : La requête DELETE	: /api/homeappliances/[REDACTED]/programs/active a réussi code = 204 résultat =
[2023-03-04 11:52:33][DEBUG] : Réponse du serveur :
[2023-03-04 11:52:33][DEBUG] : Fonction updateApplianceData()
[2023-03-04 11:52:33][DEBUG] : Mise à jour du status connecté

---> But this time the cofee maker is stopping
[2023-03-04 11:52:33][DEBUG] : Mise à jour setting : GET::BSH.Common.Status.OperationState - Valeur :Abandon
[2023-03-04 11:52:33][DEBUG] : Nombre de requêtes envoyées aujourd'hui 377
[2023-03-04 11:52:33][DEBUG] : La requête GET	: /api/homeappliances a réussi code = 200 résultat = { "data": { "homeappliances": [{ "brand": "Siemens", "connected": true, "enumber": "[REDACTED]", "haId": "[REDACTED]", "name": "Machine à café", "type": "CoffeeMaker", "vib": "[REDACTED]" }] } }
[2023-03-04 11:52:33][DEBUG] : Appareil Array ( [brand] => Siemens [connected] => 1 [enumber] => [REDACTED] [haId] => [REDACTED] [name] => Machine à café [type] => CoffeeMaker [vib] => [REDACTED] )
[2023-03-04 11:52:33][DEBUG] : Mise à jour commande connectée valeur 1
[2023-03-04 11:52:33][DEBUG] : MAJ du programme actif
[...]
[2023-03-04 11:52:33][DEBUG] : status : Array ( [key] => BSH.Common.Status.OperationState [value] => BSH.Common.EnumType.OperationState.Aborting [name] => Statut de fonctionnement [displayvalue] => Abandonner )
[2023-03-04 11:52:33][DEBUG] : Mise à jour setting : GET::BSH.Common.Status.OperationState - Valeur :Abandon
[...]
[2023-03-04 11:52:33][DEBUG] : setting : Array ( [key] => BSH.Common.Setting.PowerState [value] => BSH.Common.EnumType.PowerState.On [name] => Statut [displayvalue] => Activé )
[2023-03-04 11:52:33][DEBUG] : Mise à jour setting : GET::BSH.Common.Setting.PowerState - Valeur :Activé
[2023-03-04 11:52:45][DEBUG] : Mise à jour setting : GET::BSH.Common.Option.ProgramProgress - Valeur :100
[2023-03-04 11:52:45][DEBUG] : Mise à jour setting : GET::BSH.Common.Status.OperationState - Valeur :Prêt
[2023-03-04 11:52:45][DEBUG] : la commande info : GET::BSH.Common.Root.ActiveProgram n'a pas de valeur
[2023-03-04 11:52:45][DEBUG] : Mise à jour setting : GET::BSH.Common.Root.ActiveProgram - Valeur :
[2023-03-04 11:52:45][DEBUG] : Mise à jour setting : GET::BSH.Common.Option.ProgramProgress - Valeur :0
```

Hope it helps,
Bad